### PR TITLE
replace compile status numbers with class constants

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -615,16 +615,6 @@ class TeamViewSet(viewsets.GenericViewSet,
         return Response(serializer.data, status.HTTP_200_OK)
 
 
-class CompileStatus:
-    """
-    Class used to enum compile status constants used in compilation_update
-    """
-    PROGRESS = 0
-    SUCCESS = 1
-    FAIL = 2
-    ERROR = 3
-
-
 class SubmissionViewSet(viewsets.GenericViewSet,
                   mixins.CreateModelMixin,
                   mixins.RetrieveModelMixin):

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -95,6 +95,15 @@ ELO_START = 1200
 # real elo will more or less never get to 0 so this is fine
 ELO_NULL = -1000000
 
+class CompileStatus:
+    """
+    Class used to enum compile status constants used in compilation_update
+    """
+    PROGRESS = 0
+    SUCCESS = 1
+    FAIL = 2
+    ERROR = 3
+
 
 # Application definition
 


### PR DESCRIPTION
changed numbers to class constants for readability -- is this what you had envisioned @n8kim1 ? 