### PR TITLE
Miscellaneous updates

### DIFF
--- a/engine/src/main/battlecode/common/GameConstants.java
+++ b/engine/src/main/battlecode/common/GameConstants.java
@@ -58,6 +58,15 @@ public class GameConstants {
     /** The number of rounds a buff is applied. */
     public static final int EXPOSE_BUFF_NUM_ROUNDS = 50;
 
+    /** The initial amount of influence for each player-owned Enlightenment Center. */
+    public static final int INITIAL_ENLIGHTENMENT_CENTER_INFLUENCE = 150;
+
+    /** The passive influence ratio for Enlightenment Centers. To multiply by sqrt(roundNum). */
+    public static final float PASSIVE_INFLUENCE_RATIO_ENLIGHTENMENT_CENTER = 0.2;
+
+    /** The passive influence ratio for Slanderers. To multiply by robot influence. */
+    public static final float PASSIVE_INFLUENCE_RATIO_SLANDERER = 0.05;
+
     // *********************************
     // ****** GAMEPLAY PROPERTIES ******
     // *********************************

--- a/engine/src/main/battlecode/common/RobotType.java
+++ b/engine/src/main/battlecode/common/RobotType.java
@@ -187,6 +187,23 @@ public enum RobotType {
         return influence;
     }
 
+    /**
+     * Returns the amount of passive influence that this robot generates.
+     *
+     * @param robotInfluence  the amount of influence that this robot has
+     * @param roundNum  the round number
+     */
+    public int getPassiveInfluence(int robotInfluence, int roundNum) {
+        switch (this) {
+            case ENLIGHTENMENT_CENTER:
+                return int(Math.ceil(GameConstants.PASSIVE_INFLUENCE_RATIO_ENLIGHTENMENT_CENTER * Math.sqrt(roundNum)));
+            case SLANDERER:
+                return int(GameConstants.PASSIVE_INFLUENCE_RATIO_SLANDERER * influence);
+            default:
+                return 0;
+        }
+    }
+
     RobotType(RobotType spawnSource, float convictionRatio, float actionCooldown,
               int actionRadiusSquared, int sensorRadiusSquared, int detectionRadiusSquared,
               int bytecodeLimit) {

--- a/engine/src/main/battlecode/server/Server.java
+++ b/engine/src/main/battlecode/server/Server.java
@@ -339,20 +339,17 @@ public strictfp class Server implements Runnable {
         DominationFactor dom = stats.getDominationFactor();
 
         switch (dom) {
-            case HQ_DESTROYED:
-                sb.append("The winning team won by enemy HQ being destroyed.");
+            case ANNIHILATED:
+                sb.append("The winning team won by destroying the enemy team.");
                 break;
-            case QUANTITY_OVER_QUALITY:
-                sb.append("The winning team won on tiebreakers (more robots).");
+            case MORE_VOTES:
+                sb.append("The winning team won by having more votes.");
                 break;
-            case QUALITY_OVER_QUANTITY:
-                sb.append("The winning team won on tiebreakers (higher net worth: soup + soup cost of robots).");
+            case MORE_ENLIGHTENMENT_CENTERS:
+                sb.append("The winning team won on tiebreakers (more enlightenment centers).");
                 break;
-            case GOSSIP_GIRL:
-                sb.append("The winning team won on tiebreakers (more successful broadcasts).");
-                break;
-            case HIGHBORN:
-                sb.append("The winning team won arbitrarily (highest robot ID).");
+            case MORE_INFLUENCE:
+                sb.append("The winning team won on tiebreakers (more total influence).");
                 break;
             case WON_BY_DUBIOUS_REASONS:
                 sb.append("The winning team won arbitrarily (coin flip).");

--- a/engine/src/main/battlecode/world/DominationFactor.java
+++ b/engine/src/main/battlecode/world/DominationFactor.java
@@ -23,5 +23,5 @@ public enum DominationFactor {
     /**
      * Win by coinflip (tiebreak 3).
      */
-    WON_BY_DUBIOUS_REASONS
+    WON_BY_DUBIOUS_REASONS,
 }

--- a/engine/src/main/battlecode/world/GameWorld.java
+++ b/engine/src/main/battlecode/world/GameWorld.java
@@ -61,7 +61,7 @@ public strictfp class GameWorld {
 
         // Add the robots contained in the LiveMap to this world.
         for (RobotInfo robot : this.gameMap.getInitialBodies()) {
-            spawnRobot(-1, robot.ID, robot.type, robot.location, robot.team, robot.influence);
+            spawnRobot(null, robot.ID, robot.type, robot.location, robot.team, robot.influence);
         }
 
         // Write match header at beginning of match
@@ -422,8 +422,8 @@ public strictfp class GameWorld {
     // ****** SPAWNING *****************
     // *********************************
 
-    public int spawnRobot(int parentID, int ID, RobotType type, MapLocation location, Team team, int influence) {
-        InternalRobot robot = new InternalRobot(this, parentID, ID, type, location, team, influence);
+    public int spawnRobot(InternalRobot parent, int ID, RobotType type, MapLocation location, Team team, int influence) {
+        InternalRobot robot = new InternalRobot(this, parent, ID, type, location, team, influence);
         objectInfo.spawnRobot(robot);
         addRobot(location, robot);
 
@@ -432,9 +432,9 @@ public strictfp class GameWorld {
         return ID;
     }
 
-    public int spawnRobot(int parentID, RobotType type, MapLocation location, Team team, int influence) {
+    public int spawnRobot(InternalRobot parent, RobotType type, MapLocation location, Team team, int influence) {
         int ID = idGenerator.nextID();
-        return spawnRobot(parentID, ID, type, location, team, influence);
+        return spawnRobot(parent, ID, type, location, team, influence);
     }
    
     // *********************************

--- a/engine/src/main/battlecode/world/InternalRobot.java
+++ b/engine/src/main/battlecode/world/InternalRobot.java
@@ -13,7 +13,13 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
     private final RobotControllerImpl controller;
     private final GameWorld gameWorld;
 
-    private final int parentID;
+    /**
+     * The robot that built this robot.
+     * Equal to null if this is an Enlightenment Center, because they are specified by the map.
+     * This reference does not inhibit garbage collection because Enlightenment Centers never die.
+     */
+    private final InternalRobot parent;
+
     private final int ID;
     private Team team;
     private RobotType type;
@@ -48,8 +54,8 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
      * @param influence the influence used to create the robot
      */
     @SuppressWarnings("unchecked")
-    public InternalRobot(GameWorld gw, int parentID, int id, RobotType type, MapLocation loc, Team team, int influence) {
-        this.parentID = parentID;
+    public InternalRobot(GameWorld gw, InternalRobot parent, int id, RobotType type, MapLocation loc, Team team, int influence) {
+        this.parent = parent;
         this.ID = id;
         this.team = team;
         this.type = type;
@@ -83,8 +89,8 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
         return gameWorld;
     }
 
-    public int getParentID() {
-        return parentID;
+    public InternalRobot getParent() {
+        return parent;
     }
 
     public int getID() {
@@ -148,7 +154,7 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
                 && cachedRobotInfo.team == team
                 && cachedRobotInfo.type == infoType
                 && cachedRobotInfo.influence == influence
-                && cachedRobotInfo.conviction == conviction                
+                && cachedRobotInfo.conviction == conviction
                 && cachedRobotInfo.location.equals(location)) {
             return cachedRobotInfo;
         }
@@ -428,7 +434,12 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
     }
 
     public void processEndOfRound() {
-        // empty
+        // generate passive influence
+        InternalRobot target = (parent != null) ? parent : this;
+        if (target.getType() != RobotType.ENLIGHTENMENT_CENTER) {
+            throw new IllegalStateException("The robot's parent is not an Enlightenment Center");
+        }
+        target.addInfluenceAndConviction(type.getPassiveInfluence(this.influence, this.gameWorld.getCurrentRound()));
     }
 
     // *********************************

--- a/engine/src/main/battlecode/world/MapBuilder.java
+++ b/engine/src/main/battlecode/world/MapBuilder.java
@@ -66,7 +66,7 @@ public class MapBuilder {
                 team,
                 RobotType.ENLIGHTENMENT_CENTER,
                 influence,
-                0, // Enlightenment Centers have 0 conviction
+                influence, // Enlightenment Centers conviction == influence
                 loc
         ));
     }
@@ -131,9 +131,9 @@ public class MapBuilder {
      * @param x x position
      * @param y y position
      */
-    public void addSymmetricEnlightenmentCenter(int x, int y, int influence) {
-        addEnlightenmentCenter(x, y, Team.A, influence);
-        addEnlightenmentCenter(symmetricX(x), symmetricY(y), Team.B, influence);
+    public void addSymmetricEnlightenmentCenter(int x, int y) {
+        addEnlightenmentCenter(x, y, Team.A, GameConstants.INITIAL_ENLIGHTENMENT_CENTER_INFLUENCE);
+        addEnlightenmentCenter(symmetricX(x), symmetricY(y), Team.B, GameConstants.INITIAL_ENLIGHTENMENT_CENTER_INFLUENCE);
     }
 
     public void addSymmetricNeutralEnlightenmentCenter(int x, int y, int influence) {

--- a/engine/src/main/battlecode/world/RobotControllerImpl.java
+++ b/engine/src/main/battlecode/world/RobotControllerImpl.java
@@ -416,7 +416,7 @@ public final strictfp class RobotControllerImpl implements RobotController {
         this.robot.addInfluenceAndConviction(-influence);
         gameWorld.getMatchMaker().addAction(getID(), Action.CHANGE_INFLUENCE, -influence);
 
-        int robotID = gameWorld.spawnRobot(type, adjacentLocation(dir), getTeam());
+        int robotID = gameWorld.spawnRobot(this.robot, type, adjacentLocation(dir), getTeam(), influence);
         gameWorld.getMatchMaker().addAction(getID(), Action.SPAWN_UNIT, robotID);
     }
     

--- a/engine/src/main/battlecode/world/maps/MapTestSmall.java
+++ b/engine/src/main/battlecode/world/maps/MapTestSmall.java
@@ -38,7 +38,7 @@ public class MapTestSmall {
 
     public static void makeSimple() throws IOException {
         MapBuilder mapBuilder = new MapBuilder(mapName, 32, 32, 30);
-        mapBuilder.addSymmetricEnlightenmentCenter(5, 5, 0);
+        mapBuilder.addSymmetricEnlightenmentCenter(5, 5);
 
         for(int i = 0; i < mapBuilder.width / 2; i++) {
             for (int j = 0; j < mapBuilder.height / 2; j++) {


### PR DESCRIPTION
- Pin initial Enlightenment Center influence to constant.
- Set initial Enlightenment Center conviction to equal influence. This
  is because team changes occur upon conviction < 0.
- Add passive influence mechanics.
- Update game end human-readable descriptions.