### PR TITLE
Maps are stored in .map21 files

### DIFF
--- a/client/visualizer/src/main/scaffold.ts
+++ b/client/visualizer/src/main/scaffold.ts
@@ -116,7 +116,7 @@ export default class ScaffoldCommunicator {
         }
 
         // paths are relative for readdir
-        return cb(null, new Set(files.filter((file) => file.endsWith('.map20'))
+        return cb(null, new Set(files.filter((file) => file.endsWith('.map21'))
                   .map((file) => file.substring(0, file.length - 6))
                   .concat(Array.from(SERVER_MAPS.keys()))));
       });
@@ -132,7 +132,7 @@ export default class ScaffoldCommunicator {
       fs.mkdirSync(dir);
     }
 
-    fs.writeFile(path.join(this.scaffoldPath, 'maps', `${mapName}.map17`),
+    fs.writeFile(path.join(this.scaffoldPath, 'maps', `${mapName}.map21`),
                  new Buffer(mapData),
                  cb);
   }

--- a/client/visualizer/src/mapeditor/action/validator.ts
+++ b/client/visualizer/src/mapeditor/action/validator.ts
@@ -4,7 +4,7 @@ import {GameMap, MapUnit} from '../index';
 
 /**
  * Validates a map created by the map editor. If a map is valid, then the map
- * editor is ready to generate the .map17 file.
+ * editor is ready to generate the .map21 file.
  *
  * In a valid map:
  * - No units overlap


### PR DESCRIPTION
This PR makes the client look for .map21 files when it looks for maps in the `maps/` directory and generates maps as .map21 files instead of .map17.