### PR TITLE
MINIMUM_TERRAIN_PASSABILITY MAXIMUM_TERRAIN_PASSABILITY GameConstants

### DIFF
--- a/engine/src/main/battlecode/common/GameConstants.java
+++ b/engine/src/main/battlecode/common/GameConstants.java
@@ -26,6 +26,12 @@ public class GameConstants {
 
     /** The maximum possible map width. */
     public static final int MAP_MAX_WIDTH = 64;
+    
+    /** The minimum possible passability for a MapLocation */
+    public static final double MINIMUM_TERRAIN_PASSABILITY = 0.1;
+    
+    /** The maximum possible passability for a MapLocation */
+    public static final double MAXIMUM_TERRAIN_PASSABILITY = 1.0;
 
     // *********************************
     // ****** GAME PARAMETERS **********

--- a/engine/src/main/battlecode/world/GameWorld.java
+++ b/engine/src/main/battlecode/world/GameWorld.java
@@ -173,7 +173,14 @@ public strictfp class GameWorld {
     }
 
     public double getPassability(MapLocation loc) {
-        return this.passability[locationToIndex(loc)];
+        double passability = this.passability[locationToIndex(loc)];
+        if (passability < GameConstants.MINIMUM_TERRAIN_PASSABILITY) {
+            return GameConstants.MINIMUM_TERRAIN_PASSABILITY;
+        }
+        if (passability > GameConstants.MAXIMUM_TERRAIN_PASSABILITY) {
+            return GameConstants.MAXIMUM_TERRAIN_PASSABILITY;
+        }
+        return passability;
     }
 
     /**


### PR DESCRIPTION
not elegant but I wanted to add code to respect the following line from the specs.

> The map defines the Martian terrain: each map square has a certain passability, which is a real number between 0.1 and 1.0, inclusive.

 I could not find a reference in the code to the passability boundaries. Apologies if this has been already done and I have overlooked it. 