### PR TITLE
Add option to hide indicators:

### DIFF
--- a/engine/src/main/battlecode/server/Config.java
+++ b/engine/src/main/battlecode/server/Config.java
@@ -58,6 +58,7 @@ public class Config {
         defaults.setProperty("bc.engine.silence-c", "false");
         defaults.setProperty("bc.engine.silence-d", "false");
         defaults.setProperty("bc.engine.debug-methods", "false");
+        defaults.setProperty("bc.engine.show-indicators", "true");
 
         defaults.setProperty("bc.game.team-a", "team000");
         defaults.setProperty("bc.game.team-b", "team000");

--- a/engine/src/main/battlecode/server/GameMaker.java
+++ b/engine/src/main/battlecode/server/GameMaker.java
@@ -99,10 +99,16 @@ public strictfp class GameMaker {
     private final MatchMaker matchMaker;
 
     /**
+     * Whether to serialize indicator dots and lines into the flatbuffer.
+     */
+    private final boolean showIndicators;
+
+    /**
      * @param gameInfo the mapping of teams to bytes
      * @param packetSink the NetServer to send packets to
+     * @param showIndicators whether to write indicator dots and lines to replay
      */
-    public GameMaker(final GameInfo gameInfo, final NetServer packetSink){
+    public GameMaker(final GameInfo gameInfo, final NetServer packetSink, final boolean showIndicators) {
         this.state = State.GAME_HEADER;
 
         this.gameInfo = gameInfo;
@@ -119,6 +125,8 @@ public strictfp class GameMaker {
         this.matchFooters = new TIntArrayList();
 
         this.matchMaker = new MatchMaker();
+
+        this.showIndicators = showIndicators;
     }
 
     /**
@@ -534,6 +542,9 @@ public strictfp class GameMaker {
         }
 
         public void addIndicatorDot(int id, MapLocation loc, int red, int green, int blue) {
+            if (!showIndicators) {
+                return;
+            }
             indicatorDotIDs.add(id);
             indicatorDotLocsX.add(loc.x);
             indicatorDotLocsY.add(loc.y);
@@ -543,6 +554,9 @@ public strictfp class GameMaker {
         }
 
         public void addIndicatorLine(int id, MapLocation startLoc, MapLocation endLoc, int red, int green, int blue) {
+            if (!showIndicators) {
+                return;
+            }
             indicatorLineIDs.add(id);
             indicatorLineStartLocsX.add(startLoc.x);
             indicatorLineStartLocsY.add(startLoc.y);

--- a/engine/src/main/battlecode/server/Server.java
+++ b/engine/src/main/battlecode/server/Server.java
@@ -146,7 +146,7 @@ public strictfp class Server implements Runnable {
                 return;
             }
 
-            GameMaker gameMaker = new GameMaker(currentGame, netServer);
+            GameMaker gameMaker = new GameMaker(currentGame, netServer, options.getBoolean("bc.engine.show-indicators"));
             gameMaker.makeGameHeader();
 
             debug("Running: "+currentGame);

--- a/engine/src/test/battlecode/server/GameMakerTest.java
+++ b/engine/src/test/battlecode/server/GameMakerTest.java
@@ -38,14 +38,14 @@ public class GameMakerTest {
 
     @Test(expected=RuntimeException.class)
     public void testStateExceptions() {
-        GameMaker gm = new GameMaker(info, null);
+        GameMaker gm = new GameMaker(info, null, true);
 
         gm.makeGameFooter(Team.A);
     }
 
     @Test(expected=RuntimeException.class)
     public void testMatchStateExceptions() {
-        GameMaker gm = new GameMaker(info, null);
+        GameMaker gm = new GameMaker(info, null, true);
         gm.makeGameHeader();
         gm.getMatchMaker().makeMatchFooter(Team.A, 23);
     }
@@ -53,7 +53,7 @@ public class GameMakerTest {
     // @Test
     // public void fullReasonableGame() throws Exception {
     //     NetServer mockServer = Mockito.mock(NetServer.class);
-    //     GameMaker gm = new GameMaker(info, mockServer);
+    //     GameMaker gm = new GameMaker(info, mockServer, true);
 
     //     gm.makeGameHeader();
     //     GameMaker.MatchMaker mm = gm.getMatchMaker();


### PR DESCRIPTION
Indicator dots/lines can take up to 70% of flatbuffer size. Flatbuffers have been reporting size-limit-exceeded in prod and we expect this to alleviate the issue.