### PR TITLE
Resolve overflow by limiting influence gain

### DIFF
--- a/client/visualizer/src/config.ts
+++ b/client/visualizer/src/config.ts
@@ -124,7 +124,7 @@ export enum Mode {
  */
 export function defaults(supplied?: any): Config {
   let conf: Config = {
-    gameVersion: "2021.2.1.1", //TODO: Change this on each release!
+    gameVersion: "2021.2.2.0", //TODO: Change this on each release!
     fullscreen: false,
     width: 600,
     height: 600,

--- a/engine/src/main/battlecode/common/GameConstants.java
+++ b/engine/src/main/battlecode/common/GameConstants.java
@@ -76,6 +76,9 @@ public class GameConstants {
     /** The passive influence ratio for Enlightenment Centers. To multiply by sqrt(roundNum). */
     public static final float PASSIVE_INFLUENCE_RATIO_ENLIGHTENMENT_CENTER = 0.2f;
 
+    /** Maximum allowable robot influence. */
+    public static final int ROBOT_INFLUENCE_LIMIT = 100000000;
+
     /** The minimum allowable flag value. */
     public static final int MIN_FLAG_VALUE = 0;
 

--- a/engine/src/main/battlecode/world/InternalRobot.java
+++ b/engine/src/main/battlecode/world/InternalRobot.java
@@ -372,7 +372,7 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
         if (numBots == 0)
             return;
         
-        long convictionToGive = (long) (this.conviction * this.gameWorld.getTeamInfo().getBuff(this.team));
+        long convictionToGive = (long) (((long) this.conviction) * this.gameWorld.getTeamInfo().getBuff(this.team));
         convictionToGive -= GameConstants.EMPOWER_TAX;
         if (convictionToGive <= 0)
             return;
@@ -390,6 +390,7 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
                 conv++;
                 numBotsWithExtraConviction--;
             }
+            // HACK[jerry]: this is the maximum amount the unit can be affected by
             conv = Math.min(conv, bot.getInfluenceCap() * 2);
             bot.empowered(this, (int) conv, this.team);
         }

--- a/engine/src/main/battlecode/world/InternalRobot.java
+++ b/engine/src/main/battlecode/world/InternalRobot.java
@@ -66,7 +66,7 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
         this.location = loc;
         this.influence = influence;
         this.conviction = (int) Math.ceil(this.type.convictionRatio * this.influence);
-        this.convictionCap = type == RobotType.ENLIGHTENMENT_CENTER ? Integer.MAX_VALUE : this.conviction;
+        this.convictionCap = type == RobotType.ENLIGHTENMENT_CENTER ? 1e8 : this.conviction;
         this.flag = 0;
         this.bid = 0;
 

--- a/engine/src/main/battlecode/world/InternalRobot.java
+++ b/engine/src/main/battlecode/world/InternalRobot.java
@@ -27,6 +27,7 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
     private RobotType type;
     private MapLocation location;
     private int influence;
+    private final int influenceCap;
     private int conviction;
     private int convictionCap;
     private int flag;
@@ -65,8 +66,9 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
         this.type = type;
         this.location = loc;
         this.influence = influence;
+        this.influenceCap = 100000000;
         this.conviction = (int) Math.ceil(this.type.convictionRatio * this.influence);
-        this.convictionCap = type == RobotType.ENLIGHTENMENT_CENTER ? 1e8 : this.conviction;
+        this.convictionCap = type == RobotType.ENLIGHTENMENT_CENTER ? this.influenceCap : this.conviction;
         this.flag = 0;
         this.bid = 0;
 
@@ -287,12 +289,18 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
      * @param influenceAmount the amount to change influence by (can be negative)
      */
     public void addInfluenceAndConviction(int influenceAmount) {
+        int oldInfluence = this.influence;
         this.influence += influenceAmount;
+        if (this.influence > this.influenceCap) {
+            this.influence = this.influenceCap;
+        }
         this.conviction = this.influence;
-        this.gameWorld.getMatchMaker().addAction(getID(), Action.CHANGE_INFLUENCE, influenceAmount);
-        this.gameWorld.getMatchMaker().addAction(getID(), Action.CHANGE_CONVICTION, influenceAmount);
+        if (this.influence != oldInfluence) {
+            this.gameWorld.getMatchMaker().addAction(getID(), Action.CHANGE_INFLUENCE, this.influence - oldInfluence);
+            this.gameWorld.getMatchMaker().addAction(getID(), Action.CHANGE_CONVICTION, this.influence - oldInfluence);
+        }
     }
-    
+
     /**
      * Sets the action cooldown given the number of turns.
      * 

--- a/engine/src/main/battlecode/world/InternalRobot.java
+++ b/engine/src/main/battlecode/world/InternalRobot.java
@@ -122,6 +122,10 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
         return influence;
     }
 
+    public int getInfluenceCap() {
+        return influenceCap;
+    }
+
     public int getConviction() {
         return conviction;
     }
@@ -368,25 +372,26 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
         if (numBots == 0)
             return;
         
-        int convictionToGive = (int) (this.conviction * this.gameWorld.getTeamInfo().getBuff(this.team));
+        long convictionToGive = (long) (this.conviction * this.gameWorld.getTeamInfo().getBuff(this.team));
         convictionToGive -= GameConstants.EMPOWER_TAX;
         if (convictionToGive <= 0)
             return;
         
-        int convictionPerBot = convictionToGive / numBots;
-        int numBotsWithExtraConviction = convictionToGive % numBots;
+        long convictionPerBot = convictionToGive / numBots;
+        long numBotsWithExtraConviction = convictionToGive % numBots;
 
         Arrays.sort(robots);
         for (InternalRobot bot : robots) {
             // check if this robot
             if (bot.equals(this))
                 continue;
-            int conv = convictionPerBot;
+            long conv = convictionPerBot;
             if (numBotsWithExtraConviction > 0) {
                 conv++;
                 numBotsWithExtraConviction--;
             }
-            bot.empowered(this, conv, this.team);
+            conv = Math.min(conv, bot.getInfluenceCap() * 2);
+            bot.empowered(this, (int) conv, this.team);
         }
 
         // create new bots

--- a/engine/src/main/battlecode/world/InternalRobot.java
+++ b/engine/src/main/battlecode/world/InternalRobot.java
@@ -27,7 +27,6 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
     private RobotType type;
     private MapLocation location;
     private int influence;
-    private final int influenceCap;
     private int conviction;
     private int convictionCap;
     private int flag;
@@ -66,9 +65,8 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
         this.type = type;
         this.location = loc;
         this.influence = influence;
-        this.influenceCap = 100000000;
         this.conviction = (int) Math.ceil(this.type.convictionRatio * this.influence);
-        this.convictionCap = type == RobotType.ENLIGHTENMENT_CENTER ? this.influenceCap : this.conviction;
+        this.convictionCap = type == RobotType.ENLIGHTENMENT_CENTER ? GameConstants.ROBOT_INFLUENCE_LIMIT : this.conviction;
         this.flag = 0;
         this.bid = 0;
 
@@ -120,10 +118,6 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
 
     public int getInfluence() {
         return influence;
-    }
-
-    public int getInfluenceCap() {
-        return influenceCap;
     }
 
     public int getConviction() {
@@ -295,8 +289,8 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
     public void addInfluenceAndConviction(int influenceAmount) {
         int oldInfluence = this.influence;
         this.influence += influenceAmount;
-        if (this.influence > this.influenceCap) {
-            this.influence = this.influenceCap;
+        if (this.influence > GameConstants.ROBOT_INFLUENCE_LIMIT) {
+            this.influence = GameConstants.ROBOT_INFLUENCE_LIMIT;
         }
         this.conviction = this.influence;
         if (this.influence != oldInfluence) {
@@ -391,7 +385,7 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
                 numBotsWithExtraConviction--;
             }
             // HACK[jerry]: this is the maximum amount the unit can be affected by
-            conv = Math.min(conv, bot.getInfluenceCap() * 2);
+            conv = Math.min(conv, GameConstants.ROBOT_INFLUENCE_LIMIT * 2);
             bot.empowered(this, (int) conv, this.team);
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ teamB=examplefuncsplayer
 maps=maptestsmall
 source=src
 mapLocation=maps
-release_version=2021.2.1.1
+release_version=2021.2.2.0

--- a/specs/specs.md.html
+++ b/specs/specs.md.html
@@ -16,7 +16,7 @@
 
 **Battlecode: Campaign**
   *The formal specification of the Battlecode 2021 game.*
-  Current version: 2021.2.1.0
+  Current version: 2021.2.2.0
 
 Welcome to Battlecode 2021: Campaign.
 This is a high-level overview of this year's game.
@@ -108,6 +108,8 @@ The core resource is **influence**.
 Wielding influence enables you to amass a larger and more powerful army of robots.
 Influence is not a global resource: your team's influence is distributed among your Enlightenment Centers,
 and is generated passively both by the Enlightenment Centers and by specific robot types.
+
+Each robot has a hard limit of $10^8$ influence: any influence in excessive of this will be permanently lost.
 
 ## Overview: Votes
 
@@ -472,7 +474,8 @@ We'll update this spec as the competition progresses.
 
 # Changelog
 
-- Version 2021.2.1.2 (not yet released)
+- Version 2021.2.2.0 (1/12/21)
+    - Limit maximum robot influence to $10^8$, and supply `GameConstants.ROBOT_INFLUENCE_LIMIT`.
     - Small visual improvements to client
 
 - Version 2021.2.1.1 (1/11/21)


### PR DESCRIPTION
*This proposal is still a draft and subject to extensive discussion among Teh Devs.*

Exponentiation enables units to grow ridiculously large, sometimes overflowing `Integer.MAX_VALUE`. This is not resolvable by using 64-bit arithmetic, because the rate of exponentiation will easily also exceed `Long.MAX_VALUE`. To resolve this, we propose the following change:

- Limit maximum robot influence to 10^8. Any influence in excess of this will be lost, permanently. This includes influence from all sources:
    - Passive influence gain.
    - Politician empowering (plus muckraker buff).
    - Slanderer influence gain.

Internally we then use 64-bit arithmetic to complete the calculations, and cast back to 32-bits after applying the influence cap.