### PR TITLE
Make auto-accept checkbox toggle unranked auto-accept mode

### DIFF
--- a/frontend/src/components/rankingTeamList.js
+++ b/frontend/src/components/rankingTeamList.js
@@ -52,7 +52,7 @@ class RankingTeamList extends TeamList {
                             <td>{ team.users.join(", ") }</td>
                             <td>{ team.bio }</td>
                             <td>{ team.student ? "✅" : "🛑"}{(team.student && team.mit) ? "🐥" : ""}</td>
-                            <td>{ team.auto_accept_ranked ? "Yes" : "No"}</td>
+                            <td>{ team.auto_accept_unranked ? "Yes" : "No"}</td>
                             {props.canRequest && (
                                 <td><button className="btn btn-xs" onClick={() => this.onTeamRequest(team.id)}>{buttonContent}</button>  </td>
                             )}

--- a/frontend/src/views/team.js
+++ b/frontend/src/views/team.js
@@ -129,7 +129,7 @@ class YesTeam extends Component {
                             </div>
                             <div className="row">
                                 <div className="col-md-6">
-                                    <label id="auto_accept_ranked" className="center-row"><input type="checkbox" checked={ this.state.team.auto_accept_ranked } onChange={this.changeHandler} className="form-control center-row-start" /> Auto-accept scrimmages.</label>
+                                    <label id="auto_accept_unranked" className="center-row"><input type="checkbox" checked={ this.state.team.auto_accept_unranked } onChange={this.changeHandler} className="form-control center-row-start" /> Auto-accept scrimmages.</label>
                                 </div>
                             </div>
                             <div className="row">


### PR DESCRIPTION
This PR fixes the auto-accept situation: at the moment it is impossible to disable auto-accept for unranked scrimmages (which all manually requested scrimmages are). Instead, we can only set the auto-accept mode for ranked scrimmages, which is useless because those are ran by Teh Devs and are ran regardless of whether a participant wants it to happen.

This PR fixes that by making the auto-accept checkbox on the Team page set the auto-accept mode for unranked scrimmages and by making the auto-accept column in the Ranking show the auto-accept mode for unranked scrimmages.