### PR TITLE
Profiler fixes

### DIFF
--- a/client/visualizer/package-lock.json
+++ b/client/visualizer/package-lock.json
@@ -4428,11 +4428,6 @@
         }
       }
     },
-    "is-docker": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
-      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw=="
-    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4586,12 +4581,9 @@
       "dev": true
     },
     "is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "requires": {
-        "is-docker": "^2.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -5331,15 +5323,6 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "open": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.2.0.tgz",
-      "integrity": "sha512-4HeyhxCvBTI5uBePsAdi55C5fmqnWZ2e2MlmvWi5KW5tdH5rxoiv/aMtbeVxKZc3eWkT1GymMnLG8XC4Rq4TDQ==",
-      "requires": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
       }
     },
     "opn": {
@@ -6689,11 +6672,21 @@
       }
     },
     "speedscope": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/speedscope/-/speedscope-1.12.1.tgz",
-      "integrity": "sha512-NzCqVR274NVKWQ6OFHw6GIQEgnL63SWP0KUtjsw7L+bqnG77FeS7SdpnfX0pA24RuSv1d419Aa7s5OtUHxtBfQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/speedscope/-/speedscope-1.5.2.tgz",
+      "integrity": "sha512-oGFmFEbhqQawTlOJMhyLNyB0nl+PEZKnAPOXZiRc+o1Mb++MAP/wb5aB2OEUZhg/7FoFgYGft9qmPz78FRAu4A==",
       "requires": {
-        "open": "7.2.0"
+        "opn": "5.3.0"
+      },
+      "dependencies": {
+        "opn": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+          "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+          "requires": {
+            "is-wsl": "^1.1.0"
+          }
+        }
       }
     },
     "split-string": {

--- a/client/visualizer/package.json
+++ b/client/visualizer/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/battlecode/battlecode21#readme",
   "dependencies": {
     "battlecode-playback": "file:../playback",
-    "speedscope": "^1.12.1",
+    "speedscope": "1.5.2",
     "victor": "^1.1.0"
   },
   "devDependencies": {

--- a/client/visualizer/src/main/sidebar.ts
+++ b/client/visualizer/src/main/sidebar.ts
@@ -189,7 +189,7 @@ export default class Sidebar {
     <a href="https://github.com/battlecode/battlecode21-scaffold/blob/master/build.gradle" target="_blank">scaffold player</a>.
     Make sure to add the "profilerEnabled" property to your
     <a href="https://github.com/battlecode/battlecode21-scaffold/blob/master/gradle.properties" target="_blank">gradle.properties</a>
-    file as well. A maximum of 10,000,000 events are recorded per team per
+    file as well. A maximum of 2,000,000 events are recorded per team per
     match if profiling is enabled to prevent the replay file from becoming
     enormous.
     <br>

--- a/engine/src/main/battlecode/instrumenter/profiler/ProfilerCollection.java
+++ b/engine/src/main/battlecode/instrumenter/profiler/ProfilerCollection.java
@@ -12,19 +12,19 @@ import java.util.Map;
  */
 public class ProfilerCollection {
     /**
-     * We record a maximum of 10,000,000 events per team per match.
-     * This equals a rough maximum of 250MB of profiling data per match,
+     * We record a maximum of 2,000,000 events per team per match.
+     * This equals a rough maximum of 50MB of profiling data per match,
      * which should prevent the client from hanging when opening a replay
      * of a match in which profiling was enabled.
      */
-    private static final int MAX_EVENTS_TO_RECORD = 10_000_000;
+    private static final int MAX_EVENTS_TO_RECORD = 2_000_000;
 
     private List<Profiler> profilers = new ArrayList<>();
 
     private List<String> frames = new ArrayList<>();
     private Map<String, Integer> frameIds = new HashMap<>();
 
-    public int recordedEvents = 0;
+    private int recordedEvents = 0;
 
     public Profiler createProfiler(int robotId, RobotType robotType) {
         // The name has to be display-friendly


### PR DESCRIPTION
At the moment the profiler is causing out-of-memory issues for some participants. The reason for this is that writing all profiling data to the replay file at the end of a match needs a lot of memory. When I added the profiler I never thought about monitoring Java's memory usage, and as it turns out it can use over 5GB at the end of a match. I never noticed this because my laptop has 32GB of ram, and since the JVM limits each Java program to 25% of your total ram I never hit that limit.

I have just ran several matches to figure out what the limit of the amount of recorded profiling events is when you limit the JVM to 2GB of memory (assuming most participants have machines with at least 8GB of memory). It turns out that this limit is about 2,500,000 events per team, so in this PR I set the limit to 2,000,000 (to be safe). This should fix the memory issues.

I have also downgraded the speedscope version to the version used in the bc20 client, because I had some replay files with profiling data which for some odd reason wouldn't work with the latest version. I do not know the exact cause of this issue, but downgrading speedscope fixes it.