### PR TITLE
Fix resume uploads

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -271,8 +271,11 @@ class UserViewSet(viewsets.GenericViewSet,
     serializer_class = FullUserSerializer
     permission_classes = (IsAuthenticatedAsRequestedUser,)
 
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=['post'])
     def resume_upload(self, request, pk=None):
+        # Note that post requests always include Origin headers
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
+        # https://stackoverflow.com/questions/42239643/when-do-browsers-send-the-origin-header-when-do-browsers-set-the-origin-to-null
         origin = request.headers['Origin']        
         upload_url = GCloudUploadDownload.signed_upload_url(RESUME_FILENAME(pk), GCLOUD_RES_BUCKET, origin)
         user = self.queryset.get(pk=pk)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -431,7 +431,7 @@ class Api {
   }
 
   static resumeUpload(resume_file, callback) {
-    $.get(`${Cookies.get('user_url')}resume_upload/`, (data, succcess) => {
+    $.post(`${Cookies.get('user_url')}resume_upload/`, (data, succcess) => {
       $.ajax({
         url: data['upload_url'], 
         method: "PUT",


### PR DESCRIPTION
change to POST, so that they include an origin header, and we can use it. Also post seems more reasonable anyways (since you're in some way changing data)