### PR TITLE
Nerf muckraker buff

### DIFF
--- a/client/visualizer/src/config.ts
+++ b/client/visualizer/src/config.ts
@@ -149,7 +149,7 @@ export enum Mode {
  */
 export function defaults(supplied?: any): Config {
   let conf: Config = {
-    gameVersion: "2021.2.4.3", //TODO: Change this on each release!
+    gameVersion: "2021.3.0.0", //TODO: Change this on each release!
     fullscreen: false,
     width: 600,
     height: 600,

--- a/engine/src/main/battlecode/common/GameConstants.java
+++ b/engine/src/main/battlecode/common/GameConstants.java
@@ -53,7 +53,7 @@ public class GameConstants {
     public static final int EMPOWER_TAX = 10;
 
     /** The buff factor from exposing Slanderers. */
-    public static final double EXPOSE_BUFF_FACTOR = 1.001;
+    public static final double EXPOSE_BUFF_FACTOR = 0.001;
     
     /** The number of rounds a buff is applied. */
     public static final int EXPOSE_BUFF_NUM_ROUNDS = 50;

--- a/engine/src/main/battlecode/world/InternalRobot.java
+++ b/engine/src/main/battlecode/world/InternalRobot.java
@@ -385,14 +385,13 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
                 numBotsWithExtraConviction--;
             }
 
-            boolean convertAtZeroConviction = false;
             if (bot.type == RobotType.ENLIGHTENMENT_CENTER && bot.team == this.team) {
                 // conviction doesn't get buffed, do nothing
             } else if (bot.type == RobotType.ENLIGHTENMENT_CENTER) {
                 // complicated stuff
                 double buff = this.gameWorld.getTeamInfo().getBuff(this.team);
                 long convNeededToConvert = (long) (bot.conviction / buff);
-                while (convNeededToConvert * buff <= bot.conviction)
+                while (convNeededToConvert * buff < bot.conviction)
                     convNeededToConvert++;
                 
                 if (conv < convNeededToConvert) {
@@ -401,14 +400,13 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
                 } else {
                     // conviction buffed until conversion
                     conv = bot.conviction + (conv - convNeededToConvert);
-                    convertAtZeroConviction = true;
                 }
             } else {
                 // buff applied, cast down
                 conv = (long) (conv * this.gameWorld.getTeamInfo().getBuff(this.team));
             }
 
-            bot.empowered(this, (int) conv, this.team, convertAtZeroConviction);
+            bot.empowered(this, (int) conv, this.team);
         }
 
         // create new bots
@@ -437,7 +435,7 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
      * @param amount the amount this robot is empowered by, must be positive
      * @param newTeam the team of the robot that empowered
      */
-    public void empowered(InternalRobot caller, int amount, Team newTeam, boolean convertAtZeroConviction) {
+    public void empowered(InternalRobot caller, int amount, Team newTeam) {
         if (this.team != newTeam)
             amount = -amount;
 
@@ -446,7 +444,7 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
         else
             addConviction(amount);
 
-        if (this.conviction < 0 || (this.conviction == 0 && convertAtZeroConviction)) {
+        if (this.conviction < 0) {
             if (this.type.canBeConverted()) {
                 int newInfluence = Math.abs(this.influence);
                 int newConviction = -this.conviction;
@@ -454,10 +452,6 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
             }
             this.gameWorld.destroyRobot(getID());
         }
-    }
-
-    public void empowered(InternalRobot caller, int amount, Team newTeam) {
-        empowered(caller, amount, newTeam, false);
     }
 
     /**

--- a/engine/src/main/battlecode/world/InternalRobot.java
+++ b/engine/src/main/battlecode/world/InternalRobot.java
@@ -385,13 +385,14 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
                 numBotsWithExtraConviction--;
             }
 
+            boolean convertAtZeroConviction = false;
             if (bot.type == RobotType.ENLIGHTENMENT_CENTER && bot.team == this.team) {
                 // conviction doesn't get buffed, do nothing
             } else if (bot.type == RobotType.ENLIGHTENMENT_CENTER) {
                 // complicated stuff
                 double buff = this.gameWorld.getTeamInfo().getBuff(this.team);
                 long convNeededToConvert = (long) (bot.conviction / buff);
-                while (convNeededToConvert * buff < bot.conviction)
+                while (convNeededToConvert * buff <= bot.conviction)
                     convNeededToConvert++;
                 
                 if (conv < convNeededToConvert) {
@@ -400,13 +401,14 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
                 } else {
                     // conviction buffed until conversion
                     conv = bot.conviction + (conv - convNeededToConvert);
+                    convertAtZeroConviction = true;
                 }
             } else {
                 // buff applied, cast down
                 conv = (long) (conv * this.gameWorld.getTeamInfo().getBuff(this.team));
             }
 
-            bot.empowered(this, (int) conv, this.team);
+            bot.empowered(this, (int) conv, this.team, convertAtZeroConviction);
         }
 
         // create new bots
@@ -435,7 +437,7 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
      * @param amount the amount this robot is empowered by, must be positive
      * @param newTeam the team of the robot that empowered
      */
-    public void empowered(InternalRobot caller, int amount, Team newTeam) {
+    public void empowered(InternalRobot caller, int amount, Team newTeam, boolean convertAtZeroConviction) {
         if (this.team != newTeam)
             amount = -amount;
 
@@ -444,7 +446,7 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
         else
             addConviction(amount);
 
-        if (this.conviction < 0) {
+        if (this.conviction < 0 || (this.conviction == 0 && convertAtZeroConviction)) {
             if (this.type.canBeConverted()) {
                 int newInfluence = Math.abs(this.influence);
                 int newConviction = -this.conviction;
@@ -452,6 +454,10 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
             }
             this.gameWorld.destroyRobot(getID());
         }
+    }
+
+    public void empowered(InternalRobot caller, int amount, Team newTeam) {
+        empowered(caller, amount, newTeam, false);
     }
 
     /**

--- a/engine/src/main/battlecode/world/InternalRobot.java
+++ b/engine/src/main/battlecode/world/InternalRobot.java
@@ -366,7 +366,7 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
         if (numBots == 0)
             return;
         
-        long convictionToGive = (long) (((long) this.conviction) * this.gameWorld.getTeamInfo().getBuff(this.team));
+        long convictionToGive = this.conviction;
         convictionToGive -= GameConstants.EMPOWER_TAX;
         if (convictionToGive <= 0)
             return;
@@ -384,8 +384,28 @@ public strictfp class InternalRobot implements Comparable<InternalRobot> {
                 conv++;
                 numBotsWithExtraConviction--;
             }
-            // HACK[jerry]: this is the maximum amount the unit can be affected by
-            conv = Math.min(conv, GameConstants.ROBOT_INFLUENCE_LIMIT * 2);
+
+            if (bot.type == RobotType.ENLIGHTENMENT_CENTER && bot.team == this.team) {
+                // conviction doesn't get buffed, do nothing
+            } else if (bot.type == RobotType.ENLIGHTENMENT_CENTER) {
+                // complicated stuff
+                double buff = this.gameWorld.getTeamInfo().getBuff(this.team);
+                long convNeededToConvert = (long) (bot.conviction / buff);
+                while (convNeededToConvert * buff < bot.conviction)
+                    convNeededToConvert++;
+                
+                if (conv < convNeededToConvert) {
+                    // all of conviction is buffed
+                    conv = (long) (conv * this.gameWorld.getTeamInfo().getBuff(this.team));
+                } else {
+                    // conviction buffed until conversion
+                    conv = bot.conviction + (conv - convNeededToConvert);
+                }
+            } else {
+                // buff applied, cast down
+                conv = (long) (conv * this.gameWorld.getTeamInfo().getBuff(this.team));
+            }
+
             bot.empowered(this, (int) conv, this.team);
         }
 

--- a/engine/src/main/battlecode/world/TeamInfo.java
+++ b/engine/src/main/battlecode/world/TeamInfo.java
@@ -35,13 +35,13 @@ public class TeamInfo {
 
     // returns current buff
     public double getBuff(Team t) {
-        return Math.pow(GameConstants.EXPOSE_BUFF_FACTOR, this.numBuffs[t.ordinal()]);
+        return 1 + GameConstants.EXPOSE_BUFF_FACTOR * this.numBuffs[t.ordinal()];
     }
 
     // returns the buff at specified round
     public double getBuff(Team t, int roundNumber) {
         int buffs = getNumBuffs(t, roundNumber);
-        return Math.pow(GameConstants.EXPOSE_BUFF_FACTOR, buffs);
+        return 1 + GameConstants.EXPOSE_BUFF_FACTOR * buffs;
     }
 
     // returns the number of buffs at specified round

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ maps=maptestsmall
 profilerEnabled=false
 source=src
 mapLocation=maps
-release_version=2021.2.4.3
+release_version=2021.3.0.0

--- a/specs/specs.md.html
+++ b/specs/specs.md.html
@@ -16,7 +16,7 @@
 
 **Battlecode: Campaign**
   *The formal specification of the Battlecode 2021 game.*
-  Current version: 2021.2.4.3
+  Current version: 2021.3.0.0
 
 Welcome to Battlecode 2021: Campaign.
 This is a high-level overview of this year's game.
@@ -227,11 +227,10 @@ The politician is then destroyed, as delivering speeches is tremendously exhaust
     if the politician has less than 10 conviction, the speech will not affect other robots at all.
   - If there are $n$ nearby robots,
     then the remaining conviction will be divided into $n$ equal parts.
-    If it cannot be equally divided,
-    the extra conviction will be distributed with priority given first to later creation,
-    with ties broken by smaller robot ID.
   - Each friendly unit will gain conviction, capped at the unit's initial conviction.
+    Any buffs from Muckrakers **will** be applied here.
   - Each friendly building will gain conviction.
+    Friendly buildings **do not receive** buffs from Muckrakers.
   - Each non-friendly (enemy or neutral) robot will lose conviction.
     If its conviction becomes negative, then:
     - Politicians will be **converted** to your team,
@@ -239,7 +238,7 @@ The politician is then destroyed, as delivering speeches is tremendously exhaust
       capped at the robot's initial conviction.
     - Slanderers and muckrakers will be destroyed.
     - Buildings will be **converted** to your team,
-      with conviction equal to the absolute value of the difference.
+      although the excess conviction **does not receive** any buffs from Muckrakers.
   - Unused conviction (i.e. conviction lost due to conviction caps) will be lost forever,
     with echoes of the speech carried away by the Martian wind.
 
@@ -275,9 +274,9 @@ Muckrakers search the map, exposing the lies of enemy slanderers.
 - **Expose (active ability)**: Targets an enemy slanderer, exposing its lies and destroying it.
   For the next 50 turns,
   all speeches made by the muckraker's team will have a multiplicative factor of
-  $1.001^\text{slanderer's influence}$ applied to the total conviction of the speech,
+  $1+0.001\cdot(\text{slanderer's influence})$ applied to the total conviction of the speech,
   before the 10 units of conviction are deducted.
-  If multiple slanderers are exposed, these factors are combined multiplicatively.
+  If multiple slanderers are exposed, the total slanderer influence accumulates.
 
 ### Enlightenment Centers
 
@@ -473,6 +472,11 @@ If something is unclear, direct your questions to our [Discord](https://discord.
 We'll update this spec as the competition progresses.
 
 # Changelog
+
+- Version 2021.3.0.0 (1/22/21)
+    - Muckraker buff changed from exponential to linear (1st order Taylor expansion)
+    - Buff has no effect on friendly enlightnment centers
+    - Empowering now gets taxed before buff is applied
 
 - Version 2021.2.4.3 (1/20/21)
     - Make new maps visible in Client


### PR DESCRIPTION
- Muckraker buff changed from 1.001^numBuffs to 1 + 0.001 * numBuffs
- Empowering now gets taxed before buff is applied
- for non EC units, the conviction used is buffed
- for friendly ECs, the conviction used is not buffed
- for enemy ECs, the conviction used is buffed, up to conversion, where the remaining conviction used is not buffed
- after each scaling from buff application the amount of conviction is casted/rounded down