### PR TITLE
Visualizer Improvements

### DIFF
--- a/client/visualizer/package-lock.json
+++ b/client/visualizer/package-lock.json
@@ -88,6 +88,14 @@
         "@types/tape": "*"
       }
     },
+    "@types/chart.js": {
+      "version": "2.9.30",
+      "resolved": "https://registry.npmjs.org/@types/chart.js/-/chart.js-2.9.30.tgz",
+      "integrity": "sha512-EgjxUUZFvf6ls3kW2CwyrnSJhgyKxgwrlp/W5G9wqyPEO9iFatO63zAA7L24YqgMxiDjQ+tG7ODU+2yWH91lPg==",
+      "requires": {
+        "moment": "^2.10.2"
+      }
+    },
     "@types/debug": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
@@ -2072,6 +2080,32 @@
         }
       }
     },
+    "chart.js": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
+      "requires": {
+        "chartjs-color": "^2.1.0",
+        "moment": "^2.10.2"
+      }
+    },
+    "chartjs-color": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "requires": {
+        "chartjs-color-string": "^0.6.0",
+        "color-convert": "^1.9.3"
+      }
+    },
+    "chartjs-color-string": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "requires": {
+        "color-name": "^1.0.0"
+      }
+    },
     "chokidar": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -2199,7 +2233,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -2207,8 +2240,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colorette": {
       "version": "1.2.1",
@@ -5034,6 +5066,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/client/visualizer/package.json
+++ b/client/visualizer/package.json
@@ -25,7 +25,9 @@
   },
   "homepage": "https://github.com/battlecode/battlecode21#readme",
   "dependencies": {
+    "@types/chart.js": "^2.9.30",
     "battlecode-playback": "file:../playback",
+    "chart.js": "^2.9.4",
     "speedscope": "1.5.2",
     "victor": "^1.1.0"
   },

--- a/client/visualizer/src/gamearea/renderer.ts
+++ b/client/visualizer/src/gamearea/renderer.ts
@@ -134,6 +134,7 @@ export default class Renderer {
     const length = bodies.length;
     const types = bodies.arrays.type;
     const teams = bodies.arrays.team;
+    const convictions = bodies.arrays.conviction;
     const ids = bodies.arrays.id;
     const xs = bodies.arrays.x;
     const ys = bodies.arrays.y;
@@ -172,12 +173,12 @@ export default class Renderer {
       const effectImgs: HTMLImageElement[] = this.imgs.effects[effect];
       const whichImg = (Math.floor(curTime / cst.EFFECT_STEP) % effectImgs.length);
       const effectImg = effectImgs[whichImg];
-      this.drawBot(effectImg, x, y);
+      this.drawBot(effectImg, x, y, 0);
     }
 
     const renderBot = (i: number) => {
       const img: HTMLImageElement = this.imgs.robots[cst.bodyTypeToString(types[i])][teams[i]];
-      this.drawBot(img, realXs[i], realYs[i]);
+      this.drawBot(img, realXs[i], realYs[i], convictions[i]);
       this.drawSightRadii(realXs[i], realYs[i], types[i], ids[i] === this.lastSelectedID);
 
       // draw effect
@@ -263,11 +264,16 @@ export default class Renderer {
   /**
    * Draws an image centered at (x, y), such that an image with default size covers a 1x1 cell
    */
-  private drawBot(img: HTMLImageElement, x: number, y: number) {
+  private drawBot(img: HTMLImageElement, x: number, y: number, c: number) {
     if (this.conf.doingRotate) [x,y] = [y,x];
     let realWidth = img.naturalWidth/cst.IMAGE_SIZE;
     let realHeight = img.naturalHeight/cst.IMAGE_SIZE;
-    this.ctx.drawImage(img, x+(1-realWidth)/2, y+(1-realHeight)/2, realWidth, realHeight);
+    const sigmoid = (x) => {
+      return 1 /  (1 + Math.exp(-x))
+    }
+    this.ctx.filter = `brightness(${sigmoid(c - 100) * 30 + 90}%)`;
+    let size = sigmoid(c / 100) * 1 + 0.3;
+    this.ctx.drawImage(img, x+(1-realWidth * size)/2, y+(1-realHeight * size)/2, realWidth * size, realHeight * size);
   }
 
   private setInfoStringEvent(world: GameWorld,

--- a/client/visualizer/src/main/looper.ts
+++ b/client/visualizer/src/main/looper.ts
@@ -229,7 +229,10 @@ export default class Looper {
         // this may look innocuous, but it's a large chunk of the run time
         this.match.compute(30 /* ms */); // An ideal FPS is around 30 = 1000/30, so when compute takes its full time
                                          // FPS is lowered significantly. But I think it's a worthwhile tradeoff.
-
+            if (this.match.snapshots.length > 1) {
+                console.log(this.match.snapshots[1].turn);
+                console.log(this.match.snapshotEvery)
+            }
         // update the info string in controls
         if (this.lastSelectedID !== undefined) {
             let bodies = this.match.current.bodies.arrays;
@@ -304,13 +307,28 @@ export default class Looper {
         var totalInfluence = 0;
         let teamIDs: number[] = [];
         let teamNames: string[] = [];
+        let income = {
+
+        }
+        
         for (let team in meta.teams) {
             let teamID = meta.teams[team].teamID;
             let teamStats = world.teamStats.get(teamID) as TeamStats;
             totalInfluence += teamStats.influence.reduce((a, b) => a + b);
             teamIDs.push(teamID);
             teamNames.push(meta.teams[team].name);
+            income[teamID] = 0;
         }
+        world.bodies.arrays.type.forEach((type, i) => {
+            let team = world.bodies.arrays.team[i];
+            let ability = world.bodies.arrays.ability[i];
+            let influence = world.bodies.arrays.influence[i];
+            if (cst.abilityToEffectString(ability) === "embezzle") {
+                income[team] += Math.floor(1/50 + 0.03 * Math.exp(-0.001 * influence) * influence);
+            } else if (cst.bodyTypeToString(type) === "enlightenmentCenter") {
+                income[team] += Math.ceil(0.2 * Math.sqrt(world.turn));
+            }
+        })
         for (let team in meta.teams) {
             let teamID = meta.teams[team].teamID;
             let teamStats = world.teamStats.get(teamID) as TeamStats;
@@ -320,7 +338,10 @@ export default class Looper {
                 this.stats.setRobotCount(teamID, type, teamStats.robots[type]);
                 this.stats.setRobotConviction(teamID, type, teamStats.conviction[type]);
                 this.stats.setRobotInfluence(teamID, type, teamStats.influence[type]);
+
             });
+            
+            
 
             // Set votes
             this.stats.setVotes(teamID, teamStats.votes);
@@ -328,7 +349,13 @@ export default class Looper {
                 totalInfluence);
             this.stats.setBuffs(teamID, teamStats.numBuffs);
             this.stats.setBid(teamID, teamStats.bid);
+            this.stats.setIncome(teamID, income[teamID], world.turn);
         }
+
+        // if (this.match.current.turn - this.stats.lastSetTurn != 1) {
+        this.stats.sortIncomeGraph();
+        // }
+
         if (this.match.winner && this.match.current.turn == this.match.lastTurn) {
             this.stats.setWinner(this.match.winner, teamNames, teamIDs);
         }

--- a/client/visualizer/src/main/looper.ts
+++ b/client/visualizer/src/main/looper.ts
@@ -229,10 +229,6 @@ export default class Looper {
         // this may look innocuous, but it's a large chunk of the run time
         this.match.compute(30 /* ms */); // An ideal FPS is around 30 = 1000/30, so when compute takes its full time
                                          // FPS is lowered significantly. But I think it's a worthwhile tradeoff.
-            if (this.match.snapshots.length > 1) {
-                console.log(this.match.snapshots[1].turn);
-                console.log(this.match.snapshotEvery)
-            }
         // update the info string in controls
         if (this.lastSelectedID !== undefined) {
             let bodies = this.match.current.bodies.arrays;
@@ -351,10 +347,6 @@ export default class Looper {
             this.stats.setBid(teamID, teamStats.bid);
             this.stats.setIncome(teamID, income[teamID], world.turn);
         }
-
-        // if (this.match.current.turn - this.stats.lastSetTurn != 1) {
-        this.stats.sortIncomeGraph();
-        // }
 
         if (this.match.winner && this.match.current.turn == this.match.lastTurn) {
             this.stats.setWinner(this.match.winner, teamNames, teamIDs);

--- a/client/visualizer/src/sidebar/stats.ts
+++ b/client/visualizer/src/sidebar/stats.ts
@@ -64,7 +64,7 @@ export default class Stats {
 
   private incomeChart: Chart;
   
-  lastSetTurn: number = -1;
+  private teamMapToTurnsIncomeSet: Map<number, Set<number>> = new Map();
 
   // Note: robot types and number of teams are currently fixed regardless of
   // match info. Keep in mind if we ever change these, or implement this less
@@ -594,16 +594,20 @@ export default class Stats {
 
   setIncome(teamID: number, income: number, turn: number) {
     this.incomeDisplays[teamID].income.textContent = String(income);
-    //@ts-ignore
-    this.incomeChart.data.datasets![teamID - 1].data?.push({y:income, x: turn});
-    this.lastSetTurn = turn;
-    this.incomeChart.update();
-  }
-  sortIncomeGraph() {
-    this.incomeChart.data.datasets?.forEach((d) => {
-      d.data?.sort((a, b) => a.x - b.x);
-    });
-    this.incomeChart.update();
+    if (!this.teamMapToTurnsIncomeSet.has(teamID)) {
+      this.teamMapToTurnsIncomeSet.set(teamID, new Set());
+    }
+    let teamTurnsIncomeSet = this.teamMapToTurnsIncomeSet.get(teamID);
+    
+    if (!teamTurnsIncomeSet!.has(turn)) {
+      //@ts-ignore
+      this.incomeChart.data.datasets![teamID - 1].data?.push({y:income, x: turn});
+      this.incomeChart.data.datasets?.forEach((d) => {
+        d.data?.sort((a, b) => a.x - b.x);
+      });
+      teamTurnsIncomeSet?.add(turn);
+      this.incomeChart.update();
+    }
   }
 
   setWinner(teamID: number, teamNames: Array<string>, teamIDs: Array<number>) {

--- a/client/visualizer/src/sidebar/stats.ts
+++ b/client/visualizer/src/sidebar/stats.ts
@@ -3,6 +3,7 @@ import * as cst from '../constants';
 import { AllImages } from '../imageloader';
 import { schema } from 'battlecode-playback';
 import Runner from '../runner';
+import Chart = require('chart.js');
 
 const hex: Object = {
   1: "#db3627",
@@ -18,6 +19,10 @@ type VoteBar = {
 type BuffDisplay = {
   numBuffs: HTMLSpanElement,
   buff: HTMLSpanElement
+}
+
+type IncomeDisplay = {
+  income: HTMLSpanElement
 }
 
 /**
@@ -43,6 +48,8 @@ export default class Stats {
   private voteBars: VoteBar[];
   private maxVotes: number;
 
+  private incomeDisplays: IncomeDisplay[];
+
   private relativeBars: HTMLDivElement[];
 
   private buffDisplays: BuffDisplay[];
@@ -54,6 +61,10 @@ export default class Stats {
   private runner: Runner; //needed for file uploading in tournament mode
 
   private conf: Config;
+
+  private incomeChart: Chart;
+  
+  lastSetTurn: number = -1;
 
   // Note: robot types and number of teams are currently fixed regardless of
   // match info. Keep in mind if we ever change these, or implement this less
@@ -269,6 +280,17 @@ export default class Stats {
     });
     return buffDisplays;
   }
+  private initIncomeDisplays(teamIDs: Array<number>) {
+    const incomeDisplays: IncomeDisplay[] = [];
+    teamIDs.forEach((id: number) => {
+      const income = document.createElement("span");
+      income.style.color = hex[id];
+      income.style.fontWeight = "bold";
+      income.textContent = "1";
+      incomeDisplays[id] = {income: income};
+    });
+    return incomeDisplays;
+  }
 
   private getBuffDisplaysElement(teamIDs: Array<number>): HTMLElement {
     const table = document.createElement("table");
@@ -296,6 +318,42 @@ export default class Stats {
     table.appendChild(row);
 
     return table;
+  }
+
+  private getIncomeDisplaysElement(teamIDs: Array<number>): HTMLElement {
+    const table = document.createElement("table");
+    table.id = "income-table";
+    table.style.width = "100%";
+
+    const title = document.createElement('td');
+    title.colSpan = 2;
+    const label = document.createElement('h3');
+    label.innerText = 'Total Income Per Turn';
+
+    const row = document.createElement("tr");
+
+    teamIDs.forEach((id: number) => {
+      const cell = document.createElement("td");
+      // cell.appendChild(document.createTextNode("1.001"));
+      // cell.appendChild(this.buffDisplays[id].numBuffs);
+      // cell.appendChild(document.createTextNode(" = "));
+      cell.appendChild(this.incomeDisplays[id].income);
+      row.appendChild(cell);
+    });
+
+    title.appendChild(label);
+    table.appendChild(title);
+    table.appendChild(row);
+
+    return table;
+  }
+
+  private getIncomeDominationGraph() {
+    const canvas = document.createElement("canvas");
+    canvas.id = "myChart";
+    canvas.width = 400;
+    canvas.height = 400;
+    return canvas;
   }
 
   // private drawBuffsGraph(ctx: CanvasRenderingContext2D, upto: number) {
@@ -418,6 +476,52 @@ export default class Stats {
     const buffDivsElement = this.getBuffDisplaysElement(teamIDs);
     this.div.appendChild(buffDivsElement);
 
+    this.incomeDisplays = this.initIncomeDisplays(teamIDs);
+    const incomeElement = this.getIncomeDisplaysElement(teamIDs);
+    this.div.appendChild(incomeElement);
+
+    const canvasElement = this.getIncomeDominationGraph();
+    this.div.appendChild(canvasElement);
+    this.incomeChart = new Chart(canvasElement, {
+      type: 'line',
+      data: {
+          datasets: [{
+            label: 'Red',
+            data: [],
+            backgroundColor: 'rgba(255, 99, 132, 0)',
+            borderColor: 'rgb(219, 54, 39)',
+            pointRadius: 0,
+          },
+          {
+            label: 'Blue',
+            data: [],
+            backgroundColor: 'rgba(54, 162, 235, 0)',
+            borderColor: 'rgb(79, 126, 230)',
+            pointRadius: 0,
+          }]
+      },
+      options: {
+          scales: {
+            xAxes: [{
+              type: 'linear',
+              ticks: {
+                beginAtZero: true
+            },
+              scaleLabel: {
+                display: true,
+                labelString: "Turn"
+              }
+            }],
+              yAxes: [{
+                type: 'linear',
+                  ticks: {
+                      beginAtZero: true
+                  }
+              }]
+          }
+      }
+  });
+
     this.div.appendChild(document.createElement("br"));
     this.extraInfo = document.createElement('div');
     this.extraInfo.className = "extra-info";
@@ -486,6 +590,20 @@ export default class Stats {
     //this.buffDisplays[teamID].numBuffs.textContent = String(numBuffs);
     this.buffDisplays[teamID].buff.textContent = String(cst.buffFactor(numBuffs).toFixed(3));
     this.buffDisplays[teamID].buff.style.fontSize = 14 * Math.sqrt(Math.min(12, cst.buffFactor(numBuffs))) + "px";
+  }
+
+  setIncome(teamID: number, income: number, turn: number) {
+    this.incomeDisplays[teamID].income.textContent = String(income);
+    //@ts-ignore
+    this.incomeChart.data.datasets![teamID - 1].data?.push({y:income, x: turn});
+    this.lastSetTurn = turn;
+    this.incomeChart.update();
+  }
+  sortIncomeGraph() {
+    this.incomeChart.data.datasets?.forEach((d) => {
+      d.data?.sort((a, b) => a.x - b.x);
+    });
+    this.incomeChart.update();
   }
 
   setWinner(teamID: number, teamNames: Array<string>, teamIDs: Array<number>) {


### PR DESCRIPTION
Addresses some things the community was asking for:
1. Indication of conviction amount in units, now shown through darker to lighter shade, and smaller to bigger sized units visually
2. Income per turn and a income graph over time to show "eco dominance" or something (cool to analyze and shows a clearer indication of the economy of a team)

![Screen Shot 2021-01-25 at 3 50 31 PM](https://user-images.githubusercontent.com/35373228/105780335-0fe49780-5f25-11eb-8518-4fc42a4c2b60.png)
