### PR TITLE
Properly install npm in frontend deploy

### DIFF
--- a/frontend/deploy.sh
+++ b/frontend/deploy.sh
@@ -40,10 +40,11 @@ then
 
 	rm -r public/out
 	cd ../client
-	npm install
 	cd playback
+	npm install
 	npm run build
 	cd ../visualizer
+	npm install
 	npm run prod
 	mkdir ../../frontend/public/out
 	cp -r out ../../frontend/public


### PR DESCRIPTION
`npm install` doesn't work; either have to do `npm run install-all` or emulate it (see package.json of client folder). Here I chose the second way -- to reduce dependence on other things, and to make immediately clear what's going on